### PR TITLE
MINOR: Remove unnecessary condition

### DIFF
--- a/KafkaReplication.tla
+++ b/KafkaReplication.tla
@@ -164,7 +164,6 @@ ControllerShrinkIsr == \E replica \in Replicas :
             /\ ControllerUpdateIsr(None, quorumState.isr \ {replica})
         \/  /\ quorumState.leader # replica
             /\ replica \in quorumState.isr
-            /\ quorumState.isr # {replica}
             /\ ControllerUpdateIsr(quorumState.leader, quorumState.isr \ {replica})
     /\ UNCHANGED <<nextRecordId, replicaLog, replicaState>>
 
@@ -342,5 +341,6 @@ StrongIsr == \A r1 \in Replicas :
 
 =============================================================================
 \* Modification History
+\* Last modified Tue Dec 31 22:30:08 PST 2019 by guozhang
 \* Last modified Mon Jul 09 14:24:02 PDT 2018 by jason
 \* Created Sun Jun 10 16:16:51 PDT 2018 by jason

--- a/KafkaReplication.tla
+++ b/KafkaReplication.tla
@@ -339,8 +339,13 @@ StrongIsr == \A r1 \in Replicas :
                 /\ ReplicaLog!HasEntry(r1, record, offset)        
                 /\ ReplicaLog!HasEntry(r2, record, offset) 
 
+(**
+ * The leader should always in the ISR, because even if all brokers failed, we still keep the leader in ISR
+ *)
+LeaderInIsr == quorumState.leader \in quorumState.isr
+
 =============================================================================
 \* Modification History
-\* Last modified Tue Dec 31 22:30:08 PST 2019 by guozhang
+\* Last modified Thu Jan 02 14:37:55 PST 2020 by guozhang
 \* Last modified Mon Jul 09 14:24:02 PDT 2018 by jason
 \* Created Sun Jun 10 16:16:51 PDT 2018 by jason

--- a/Kip320.tla
+++ b/Kip320.tla
@@ -166,9 +166,11 @@ Spec == Init /\ [][Next]_vars
              /\ WF_vars(BecomeLeader)
 
 THEOREM Spec => []TypeOk
+THEOREM Spec => []LeaderInIsr
 THEOREM Spec => []WeakIsr
 THEOREM Spec => []StrongIsr
 =============================================================================
 \* Modification History
+\* Last modified Thu Jan 02 14:37:06 PST 2020 by guozhang
 \* Last modified Tue Jul 10 08:05:35 PDT 2018 by jason
 \* Created Thu Jul 05 23:45:04 PDT 2018 by jason


### PR DESCRIPTION
If the replica is not a leader, then the isr should at least contain the isr. So the third condition seem unnecessary since it should never happens that `quorumState.isr = {replica}` and `quorumState.leader # replica` at the same time.